### PR TITLE
Improve Result Page & More Meta Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,19 @@ Inspired by [How it feels to learn JavaScript in 2016](https://hackernoon.com/ho
 
 ## Contributing
 
-  1. Add a new object of a JavaScript tool to `/static/logos.json` JSON file.
+  1. Add a new object* of a JavaScript tool to [/static/logos.json](static/logos.json) JSON file.
   2. Add `100x100` .png image to `/static/logos/` directory with the tool's name in lowercase as the file's name.
   3. Create a pull request :)
+
+* Object must contain required `name` and optional `repo`, `description` and `url` keys. Example:
+```json 
+{
+  "name": "Vue",
+  "repo": "vuejs/vue",
+  "url": "https://vuejs.org",
+  "description": "The Progressive JavaScript Framework"
+}
+```
 
 ## Build Setup
 First make sure you have [Yarn](https://yarnpkg.com) installed.

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,9 @@
       v-show="testFinished"
       v-on:restart="restartTest"
       :score="answeredCount"
-      :total="totalCount">
+      :total="totalCount"
+      :current-js-tool="currentJsTool"
+    >
     </result-page>
     <credits class="credits"></credits>
   </div>

--- a/src/components/ResultPage.vue
+++ b/src/components/ResultPage.vue
@@ -2,11 +2,29 @@
   <div class="container">
     <h1>{{feedback}}</h1>
     <h2>{{score}} / {{total}}</h2>
+
+    <br>
+
+    <a class="ripple-button button" :href="`https://twitter.com/intent/tweet?text=${(twitterText)}`" target="_blank">
+      Tweet Your Score
+    </a>
+
     <button class="ripple-button button" v-on:click="restart">
       Restart
     </button>
-    <a class="twitter-share-button"
-        href="https://twitter.com/intent/tweet">Tweet</a>
+
+    <js-logo :logo="currentJsTool.name"></js-logo>
+    {{currentJsTool.name}}
+    <span v-if="currentJsTool.description"><br> {{currentJsTool.description}}</span>
+    <br><br>
+
+    <a :href="`https://github.com/${currentJsTool.repo}`" v-if="currentJsTool.repo" target="_blank">View On GitHub</a>
+    &nbsp;	&nbsp;	&nbsp;
+    <a :href="currentJsTool.url" v-if="currentJsTool.url" target="_blank">{{currentJsTool.url}}</a>
+    <br>
+
+    <br>
+    <br>
     <a class="github-button"
         href="https://github.com/samiheikki/javascript-guessing-game"
         data-icon="octicon-star"
@@ -18,8 +36,11 @@
 </template>
 
 <script>
+import JsLogo from '../components/JsLogo'
+
 export default {
-  props: ['progress', 'score', 'total'],
+  components: {JsLogo},
+  props: ['progress', 'score', 'total', 'currentJsTool'],
   data () {
     return {
       insults: [
@@ -55,6 +76,9 @@ export default {
         // 1 - 99
         return this.insults[Math.floor(Math.random() * this.insults.length)]
       }
+    },
+    twitterText: function () {
+      return `You know there are too many JS libraries when there is a game for it 🎯 \n I've got score ${this.score}/${this.total}. Try it out!`
     }
   },
   methods: {
@@ -80,5 +104,8 @@ h1 {
   .container {
     margin: 0 16px 0 16px;
   }
+}
+a.ripple-button {
+  text-decoration: none;
 }
 </style>

--- a/src/components/ResultPage.vue
+++ b/src/components/ResultPage.vue
@@ -78,7 +78,7 @@ export default {
       }
     },
     twitterText: function () {
-      return `You know there are too many JS libraries when there is a game for it 🎯 \n I've got score ${this.score}/${this.total}. Try it out!`
+      return `You know there are too many JS libraries when there is a game for it 🎯 \n I've got score ${this.score}/${this.total}. Try it out! https://javascript-game.firebaseapp.com`
     }
   },
   methods: {


### PR DESCRIPTION
Hey. This PR adds supporting more JSON meta fields including: 
- Description of project
- GithubRepo in form of `owner/repo` (This helps us retrieving more information from Github API in feature)
- URL

Also, I've made some improvements to Result page including twitter share with a message :) 

![image](https://cloud.githubusercontent.com/assets/5158436/24726622/518313c0-1a68-11e7-9413-7f045d5de12b.png)

Fixes #98 
